### PR TITLE
Remove message to configure PK

### DIFF
--- a/rpi_nio_install.sh
+++ b/rpi_nio_install.sh
@@ -67,4 +67,3 @@ echo
 echo SERVICE STARTED
 echo ---------------
 echo 'Success! nio has been successfully installed and an instance is now currently running on this machine.'
-echo 'If you would like to use pubkeeper communication, update the file nio/projects/'$proj'/nio.env and restart the nio service (sudo service '$proj' restart).'


### PR DESCRIPTION
`nio new` used in the script will give the user the option to configure their pubkeeper credentials without manually editing `nio.env`